### PR TITLE
Fix return value of SemVer::satisfiedBy

### DIFF
--- a/src/Commands/SemverSatisfiedByCommand.php
+++ b/src/Commands/SemverSatisfiedByCommand.php
@@ -25,7 +25,7 @@ final class SemverSatisfiedByCommand extends Command {
 
         $satisfies = $semver->satisfiedBy($input->getArgument('version'), $input->getArgument('constraint'));
 
-        if (false === $satisfies) {
+        if ([] === $satisfies) {
             $output->writeln('Version ' . $input->getArgument('version') . ' does not satisfy constraint ' . $input->getArgument('constraint'));
             return Command::FAILURE;
         }


### PR DESCRIPTION
`SemVer::satisfiedBy` always returns an array.

Discovered by @phpstan.

https://github.com/composer/semver/blob/1d09200268e7d1052ded8e5da9c73c96a63d18f5/src/Semver.php#L51